### PR TITLE
Hotfix 0.1.1 — added information in fourth file

### DIFF
--- a/forthFile.txt
+++ b/forthFile.txt
@@ -1,4 +1,4 @@
 forthFile.txt adds a small amount of contents.
 Some details left out and now added.
 Hotfix performed in this file. To be merged into both master and dev branches.
-Remember to bump version to 0.1.1.
+Bumped version to 0.1.1, via Releases > Draft new release and applying to Hotfix-0.1.1 repo.


### PR DESCRIPTION
Performed this hotfix entirely on GitHub website; used Release > Draft new release mechanism to bump version to tag 0.1.1.